### PR TITLE
using v instead of r derivative

### DIFF
--- a/examples/spring_mass_dumper/include/controller.hpp
+++ b/examples/spring_mass_dumper/include/controller.hpp
@@ -39,7 +39,6 @@ private:
     float _i_error;
     float _d_error;
     float _last_error;
-    float _last_r_feedback;
 
     float _p_element;
     float _i_element;

--- a/examples/spring_mass_dumper/src/controller.cpp
+++ b/examples/spring_mass_dumper/src/controller.cpp
@@ -7,7 +7,6 @@ Controller::Controller()
     _dt = TIME_STEP;
     
     _last_error = 0.0;
-    _last_r_feedback = 0.0;
 }
 
 void Controller::set_parameters(float kp, float ki, float kd, float r_req)
@@ -37,7 +36,6 @@ void Controller::step()
     _u = _p_element + _i_element + _d_element;
 
     _last_error = _error;
-    _last_r_feedback = _r;
 }
 
 void Controller::get_outputs(control_signal &control_signal)


### PR DESCRIPTION
Hi @shalevm,

I changed the d-term calculation of the controller, instead of calculating the derivative of `r`, we now use `v` measurements.